### PR TITLE
Wfh tomorrow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,7 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"env": {
-				"GOOGLE_TARGET_CALENDAR": "your_wfh_calendar@resource.calendar.google.com",
-				"GOOGLE_PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----\nyourkey\n-----END PRIVATE KEY-----\n",
-  				"GOOGLE_CLIENT_EMAIL": "your-service-account@your-service-account.iam.gserviceaccount.com",
-				"PORT": "2323",
-				"SLACK_API_TOKEN": "your-slack-api-token",
-			},
+			"envFile": "${workspaceRoot}/.env",
 			"type": "node",
 			"request": "launch",
 			"name": "Launch Program",

--- a/src/google-auth-api.js
+++ b/src/google-auth-api.js
@@ -1,0 +1,20 @@
+var GoogleAuth = require('google-auth-library');
+
+module.exports = {
+	credentials: function(email, key) {
+		var pending;
+		if (!pending) {
+			pending = new Promise((resolve, reject) => {
+				const authFactory = new GoogleAuth();
+				const jwtClient = new authFactory.JWT(
+					email,
+					null,
+					key,
+					['https://www.googleapis.com/auth/calendar']
+				);
+				jwtClient.authorize(error => error ? reject(error) : resolve(jwtClient));
+		});
+		}
+		return pending;
+	}
+}

--- a/src/google-calendar-api.js
+++ b/src/google-calendar-api.js
@@ -1,7 +1,6 @@
 var googleAuth = require('./google-auth-api');
 var google = require('googleapis');
 var calendar = google.calendar('v3').events;
-var moment = require('moment');
 
 function credentials() {
 	return googleAuth.credentials(process.env.GOOGLE_CLIENT_EMAIL, process.env.GOOGLE_PRIVATE_KEY);

--- a/src/google-calendar-api.js
+++ b/src/google-calendar-api.js
@@ -26,30 +26,7 @@ var credentials = (function() {
 })();
 
 module.exports = {
-	checkIfWfhEventExists: (employeeName, eventDate) => {
-		return new Promise(resolve =>
-			credentials().then(auth =>
-				calendar.list({
-					auth,
-					calendarId: process.env.GOOGLE_CLIENT_EMAIL,
-					singleEvents: true,
-					timeMin: moment(eventDate).startOf('day').format(),
-					timeMax: moment(eventDate).add(1, 'day').startOf('day').format()
-				}, (err, response) => {
-					var existingId;
-
-					if (response) {
-						existingId = response.items
-							.filter(i => i.summary === `${ employeeName } - WFH`)
-							.map(i => i.id)[0];
-					}
-
-					resolve(existingId);
-				})
-			)
-		);
-	},
-	checkIfWfhEventExistsInInterval: (employeeName, eventStartDateTime, eventEndDateTime) => {
+	checkIfWfhEventExists: (employeeName, eventStartDateTime, eventEndDateTime = new Date(moment(eventStartDateTime).add(1, 'day').startOf('day').format())) => {
 		return new Promise(resolve =>
 			credentials().then(auth =>
 				calendar.list({
@@ -90,7 +67,7 @@ module.exports = {
 			)
 		);
 	},
-	createWfhEventInInterval: (employeeName, eventStartDateTime, eventEndDateTime) => {
+	createWfhEvent: (employeeName, eventStartDateTime, eventEndDateTime = new Date(moment(eventStartDateTime).add(1, 'day').startOf('day').format())) => {
 		return new Promise((resolve, reject) =>
 			credentials().then(auth =>
 				calendar.insert({
@@ -100,31 +77,7 @@ module.exports = {
 						attendees: [{ email: process.env.GOOGLE_TARGET_CALENDAR }],
 						description: 'Added by your friendly, neighborhood Slackbot 🏡',
 						end: { dateTime: moment(eventEndDateTime).format() },
-						start: { dateTime: moment(eventStartDateTime).format() },
-						summary: `${ employeeName } - WFH`
-					}
-				}, (err, response) => {
-					if (err) {
-						reject(err);
-					}
-					else {
-						resolve(response);
-					}
-				})
-			)
-		);
-	},
-	createWfhEvent: (employeeName, eventDate) => {
-		return new Promise((resolve, reject) =>
-			credentials().then(auth =>
-				calendar.insert({
-					auth,
-					calendarId: 'primary',
-					resource: {
-						attendees: [{ email: process.env.GOOGLE_TARGET_CALENDAR }],
-						description: 'Added by your friendly, neighborhood Slackbot 🏡',
-						end: { dateTime: moment(eventDate).add(1, 'day').startOf('day').format() },
-						start: { dateTime: moment(eventDate).startOf('day').format() },
+						start: { dateTime: moment(eventStartDateTime) },
 						summary: `${ employeeName } - WFH`
 					}
 				}, (err, response) => {

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -1,28 +1,55 @@
 var googleApi = require('./google-calendar-api');
 var slackApi = require('./slack-api');
 
-var toggleWfhEvent = (eventId, employeeName) => {
+var toggleWfhEvent = (eventId, employeeName, date) => {
 	var action, message;
 
 	if (eventId) {
 		action = googleApi.deleteWfhEvent(eventId);
 		message = '🚗 Okay! Looks like you\'re going to the office today. 🏢';
 	} else {
-		action = googleApi.createWfhEvent(employeeName);
+		action = googleApi.createWfhEvent(employeeName, date);
 		message = '✅ Okay! You\'re on the calendar as WFH today. _Don\'t slack off_! 🏡';
 	}
 
 	return action.then(() => message);
 };
 
-module.exports = (userId, slackResponseEndpoint) =>
-	slackApi.getUserInfo(userId)
-		.then(employeeName =>
-			googleApi.checkIfWfhEventExists(employeeName)
-				.then(eventId => toggleWfhEvent(eventId, employeeName))
-				.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
-		)
-		.catch(error => {
-			console.log(error);
-			return slackApi.sendResponse(slackResponseEndpoint, '💥 Uh oh, just FYI, something went wrong and you\'re not on the calendar as WFH.');
-		})
+var clearCalendarEvent = eventId => {
+	var action, message;
+
+	if (eventId) {
+		action = googleApi.deleteWfhEvent(eventId);
+	}
+	else {
+		action = Promise.resolve();
+	}
+	message = '🚗 Okay! Looks like you\'re going to the office today. 🏢';
+
+	return action.then(() => message);
+}
+
+module.exports = {
+	handleRequest: function (userID, slackResponseEndpoint, date) {
+		return slackApi
+			.getUserInfo(userID)
+			.then(employeeName =>
+				googleApi.checkIfWfhEventExists(employeeName, date)
+					.then(eventId => toggleWfhEvent(eventId, employeeName, date))
+					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
+			)
+			.catch(error => {
+				console.log(error);
+				return slackApi.sendResponse(slackResponseEndpoint, '💥 Uh oh, just FYI, something went wrong and you\'re not on the calendar as WFH.');
+			})
+	},
+	clear: function (userID, slackResponseEndpoint, date) {
+		return slackApi
+			.getUserInfo(userID)
+			.then(employeeName =>
+				googleApi.checkIfWfhEventExists(employeeName, date)
+					.then(eventId => clearCalendarEvent(eventId))
+					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
+			);
+	}
+};

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -59,7 +59,7 @@ module.exports = {
 			.getUserInfo(userID)
 			.then(employeeName =>
 				googleApi.checkIfWfhEventExists(employeeName, startDateTime, endDateTime)
-					.then(eventId => clearCalendarEvent(eventId, startDateTime))
+					.then(eventId => clearCalendarEvent(eventId, startDateTime, endDateTime))
 					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
 			);
 	}

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -1,21 +1,22 @@
 var googleApi = require('./google-calendar-api');
 var slackApi = require('./slack-api');
+var moment = require('moment');
 
 var toggleWfhEvent = (eventId, employeeName, date) => {
 	var action, message;
 
 	if (eventId) {
 		action = googleApi.deleteWfhEvent(eventId);
-		message = '🚗 Okay! Looks like you\'re going to the office today. 🏢';
+		message = `🚗 Okay! Looks like you're going to the office on ${ moment(date).format('MMMM Do YYYY') }. 🏢`;
 	} else {
 		action = googleApi.createWfhEvent(employeeName, date);
-		message = '✅ Okay! You\'re on the calendar as WFH today. _Don\'t slack off_! 🏡';
+		message = `✅ Okay! You're on the calendar as WFH for ${ moment(date).format('MMMM Do YYYY') }. _Don't slack off_! 🏡`;
 	}
 
 	return action.then(() => message);
 };
 
-var clearCalendarEvent = eventId => {
+var clearCalendarEvent = (eventId, date) => {
 	var action, message;
 
 	if (eventId) {
@@ -24,7 +25,7 @@ var clearCalendarEvent = eventId => {
 	else {
 		action = Promise.resolve();
 	}
-	message = '🚗 Okay! Looks like you\'re going to the office today. 🏢';
+	message = `🚗 Okay! Looks like you're going to the office ${ moment(date).format('MMMM Do YYYY') }. 🏢`;
 
 	return action.then(() => message);
 }
@@ -48,7 +49,7 @@ module.exports = {
 			.getUserInfo(userID)
 			.then(employeeName =>
 				googleApi.checkIfWfhEventExists(employeeName, date)
-					.then(eventId => clearCalendarEvent(eventId))
+					.then(eventId => clearCalendarEvent(eventId, date))
 					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
 			);
 	}

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -30,7 +30,7 @@ var toggleWfhEventInInterval = (eventId, employeeName, startDateTime, endDateTim
 			message = `🚗 Okay! Looks like you're going to the office from ${ moment(startDateTime).format('MMMM Do YYYY, h:mm a') } to ${ moment(endDateTime).format('MMMM Do YYYY, h:mm a') } . 🏢`
 		}
 	} else {
-		action = googleApi.createWfhEventInInterval(employeeName, startDateTime, endDateTime);
+		action = googleApi.createWfhEvent(employeeName, startDateTime, endDateTime);
 		if (startDateTime.getDate() === endDateTime.getDate())
 		{
 			message = `✅ Okay! You're on the calendar as WFH on ${ moment(startDateTime).format('MMMM Do YYYY') } from ${ moment(startDateTime).format('h:mm a') } to ${ moment(endDateTime).format('h:mm a') }. _Don't slack off_! 🏡`
@@ -76,7 +76,7 @@ module.exports = {
 		return slackApi
 			.getUserInfo(userID)
 			.then(employeeName =>
-				googleApi.checkIfWfhEventExistsInInterval(employeeName, startDateTime, endDateTime)
+				googleApi.checkIfWfhEventExists(employeeName, startDateTime, endDateTime)
 					.then(eventId => toggleWfhEventInInterval(eventId, employeeName, startDateTime, endDateTime))
 					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
 			)

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -76,7 +76,7 @@ module.exports = {
 		return slackApi
 			.getUserInfo(userID)
 			.then(employeeName =>
-				googleApi.checkIfWfhEventExists(employeeName, startDateTime)
+				googleApi.checkIfWfhEventExistsInInterval(employeeName, startDateTime, endDateTime)
 					.then(eventId => toggleWfhEventInInterval(eventId, employeeName, startDateTime, endDateTime))
 					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
 			)

--- a/src/handle-wfh-request.js
+++ b/src/handle-wfh-request.js
@@ -7,10 +7,10 @@ var toggleWfhEvent = (eventId, employeeName, date) => {
 
 	if (eventId) {
 		action = googleApi.deleteWfhEvent(eventId);
-		message = `🚗 Okay! Looks like you're going to the office on ${ moment(date).format('MMMM Do YYYY') }. 🏢`;
+		message = `🚗 Okay! Looks like you're going to the office on ${ date.format('MMMM Do YYYY') }. 🏢`;
 	} else {
 		action = googleApi.createWfhEvent(employeeName, date);
-		message = `✅ Okay! You're on the calendar as WFH for ${ moment(date).format('MMMM Do YYYY') }. _Don't slack off_! 🏡`;
+		message = `✅ Okay! You're on the calendar as WFH for ${ date.format('MMMM Do YYYY') }. _Don't slack off_! 🏡`;
 	}
 
 	return action.then(() => message);
@@ -21,23 +21,23 @@ var toggleWfhEventInInterval = (eventId, employeeName, startDateTime, endDateTim
 
 	if (eventId) {
 		action = googleApi.deleteWfhEvent(eventId);
-		if (startDateTime.getDate() === endDateTime.getDate())
+		if (startDateTime.format() === endDateTime.format())
 		{
-			message = `🚗 Okay! Looks like you're going to the office on ${ moment(startDateTime).format('MMMM Do YYYY') } from ${ moment(startDateTime).format('h:mm a') } to ${ moment(endDateTime).format('h:mm a') }. 🏢`
+			message = `🚗 Okay! Looks like you're going to the office on ${ startDateTime.format('MMMM Do YYYY') } from ${ startDateTime.format('h:mm a') } to ${ endDateTime.format('h:mm a') }. 🏢`
 		}
 		else
 		{
-			message = `🚗 Okay! Looks like you're going to the office from ${ moment(startDateTime).format('MMMM Do YYYY, h:mm a') } to ${ moment(endDateTime).format('MMMM Do YYYY, h:mm a') } . 🏢`
+			message = `🚗 Okay! Looks like you're going to the office from ${ startDateTime.format('MMMM Do YYYY, h:mm a') } to ${ endDateTime.format('MMMM Do YYYY, h:mm a') } . 🏢`
 		}
 	} else {
 		action = googleApi.createWfhEvent(employeeName, startDateTime, endDateTime);
-		if (startDateTime.getDate() === endDateTime.getDate())
+		if (startDateTime.format() === endDateTime.format())
 		{
-			message = `✅ Okay! You're on the calendar as WFH on ${ moment(startDateTime).format('MMMM Do YYYY') } from ${ moment(startDateTime).format('h:mm a') } to ${ moment(endDateTime).format('h:mm a') }. _Don't slack off_! 🏡`
+			message = `✅ Okay! You're on the calendar as WFH on ${ startDateTime.format('MMMM Do YYYY') } from ${ startDateTime.format('h:mm a') } to ${ endDateTime.format('h:mm a') }. _Don't slack off_! 🏡`
 		}
 		else
 		{
-			message = `✅ Okay! You're on the calendar as WFH from ${ moment(startDateTime).format('MMMM Do YYYY, h:mm a') } to ${ moment(endDateTime).format('MMMM Do YYYY, h:mm a') }. _Don't slack off_! 🏡`;
+			message = `✅ Okay! You're on the calendar as WFH from ${ startDateTime.format('MMMM Do YYYY, h:mm a') } to ${ endDateTime.format('MMMM Do YYYY, h:mm a') }. _Don't slack off_! 🏡`;
 		}
 	}
 
@@ -53,7 +53,7 @@ var clearCalendarEvent = (eventId, date) => {
 	else {
 		action = Promise.resolve();
 	}
-	message = `🚗 Okay! Looks like you're going to the office ${ moment(date).format('MMMM Do YYYY') }. 🏢`;
+	message = `🚗 Okay! Looks like you're going to the office ${ date.format('MMMM Do YYYY') }. 🏢`;
 
 	return action.then(() => message);
 }
@@ -85,12 +85,12 @@ module.exports = {
 				return slackApi.sendResponse(slackResponseEndpoint, '💥 Uh oh, just FYI, something went wrong and you\'re not on the calendar as WFH.');
 			})
 	},
-	clear: function (userID, slackResponseEndpoint, date) {
+	clear: function (userID, slackResponseEndpoint, startDateTime, endDateTime) {
 		return slackApi
 			.getUserInfo(userID)
 			.then(employeeName =>
-				googleApi.checkIfWfhEventExists(employeeName, date)
-					.then(eventId => clearCalendarEvent(eventId, date))
+				googleApi.checkIfWfhEventExists(employeeName, startDateTime, endDateTime)
+					.then(eventId => clearCalendarEvent(eventId, startDateTime))
 					.then(message => slackApi.sendResponse(slackResponseEndpoint, message))
 			);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 var bodyParser = require('body-parser');
 var app = require('express')();
 var handleWfhRequest = require('./handle-wfh-request');
-var parseText = require('./parse-text')
+var parseText = require('./parse-text');
+var slackApi = require('./slack-api');
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.listen(process.env.PORT);
@@ -12,19 +13,27 @@ app.post('/wfh', (req, res) => {
 	{
 		if (parseText.checkIfDateTimeInterval(req.body.text))
 		{
-			handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+			slackApi.getUserTimezone(req.body.user_id).then(tz =>
+				handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text, tz), parseText.getEndDateTime(req.body.text, tz))
+			);
 		}
 		else
 		{
-			handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+			slackApi.getUserTimezone(req.body.user_id).then(tz =>
+				handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text, tz))
+			);
 		}
 	}
 	else if (parseText.checkIfDateTimeInterval(req.body.text))
 	{
-		handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+		slackApi.getUserTimezone(req.body.user_id).then(tz =>
+			handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text, tz), parseText.getEndDateTime(req.body.text, tz))
+		);
 	}
 	else
 	{
-		handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+		slackApi.getUserTimezone(req.body.user_id).then(tz =>
+			handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text, tz))
+		);
 	}
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ app.post('/wfh', (req, res) => {
 	{
 		handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
 	}
+	else if (parseText.checkIfDateTimeInterval(req.body.text))
+	{
+			handleWfhRequest.handleRequestInInterval(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+	}
 	else
 	{
 		handleWfhRequest.handleRequest(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,14 @@ app.post('/wfh', (req, res) => {
 	res.send();
 	if (parseText.checkIfClear(req.body.text))
 	{
-		handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+		if (parseText.checkIfDateTimeInterval(req.body.text))
+		{
+			handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+		}
+		else
+		{
+			handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+		}
 	}
 	else if (parseText.checkIfDateTimeInterval(req.body.text))
 	{

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,10 @@ app.post('/wfh', (req, res) => {
 	}
 	else if (parseText.checkIfDateTimeInterval(req.body.text))
 	{
-		handleWfhRequest.handleRequestInInterval(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+		handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
 	}
 	else
 	{
-		handleWfhRequest.handleRequest(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+		handleWfhRequest.setWfhEvent(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
 	}
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,19 @@
 var bodyParser = require('body-parser');
 var app = require('express')();
 var handleWfhRequest = require('./handle-wfh-request');
+var parseText = require('./parse-text')
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.listen(process.env.PORT);
 
 app.post('/wfh', (req, res) => {
 	res.send();
-	handleWfhRequest(req.body.user_id, req.body.response_url);
+	if (parseText.checkIfClear(req.body.text))
+	{
+		handleWfhRequest.clear(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+	}
+	else
+	{
+		handleWfhRequest.handleRequest(req.body.user_id, req.body.response_url, parseText.getDate(req.body.text));
+	}
 });

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ app.post('/wfh', (req, res) => {
 	}
 	else if (parseText.checkIfDateTimeInterval(req.body.text))
 	{
-			handleWfhRequest.handleRequestInInterval(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
+		handleWfhRequest.handleRequestInInterval(req.body.user_id, req.body.response_url, parseText.getStartDateTime(req.body.text), parseText.getEndDateTime(req.body.text));
 	}
 	else
 	{

--- a/src/parse-text.js
+++ b/src/parse-text.js
@@ -1,43 +1,30 @@
 var moment = require('moment');
 
-function adjustHours (text, start, end, hours)
+function handleAMPM(text)
 {
-	var fixedHours = hours;
-	if (text.substring(start, end).includes('PM') || text.substring(start, end).includes('pm'))
-	{
-		if (hours < 12)
-		{
-			fixedHours += 12;
-		}
-	}
-	if (text.substring(start, end).includes('AM') || text.substring(start, end).includes('am'))
+	var hours = parseInt(text.substring(0, text.search(':')), 10);
+	if ((/(AM|am)/).test(text))
 	{
 		if (hours === 12)
 		{
-			fixedHours = 0;
+			hours = 0;
 		}
 	}
-	return fixedHours;
+	else if ((/(PM|pm)/).test(text))
+	{
+		if (hours < 12)
+		{
+			hours += 12;
+		}
+	}
+	return hours;
 }
 
 function extractHoursMinutesFromString(text, searchStartIndex, searchEndIndex)
 {
-	var reachedStartOfTime = false;
-	var startOfTimeIndex, timeString, hours;
-	for (var i = searchStartIndex; i < searchEndIndex; i += 1)
-	{
-		if (!reachedStartOfTime && !isNaN(text.charAt(i)))
-		{
-			reachedStartOfTime = true;
-			startOfTimeIndex = i;
-		}
-		else if (reachedStartOfTime && text.charAt(i) === ':')
-		{
-			hours = adjustHours(text, searchStartIndex, searchEndIndex, parseInt(text.substring(startOfTimeIndex, i), 10));
-			timeString = `${ hours }${ text.substr(i, 3) }`
-			break;
-		}
-	}
+	var timeArray = (/(\w+:\w\w\s?(AM|am|PM|pm))/).exec(text.substring(searchStartIndex, searchEndIndex));
+	var timeString = `${ handleAMPM(timeArray[0]) }${ timeArray[0].substr(timeArray[0].search(':'), 3) }`;
+
 	if (timeString.length === 4)
 	{
 		timeString = `0${ timeString }`;
@@ -79,7 +66,7 @@ function extractDateTime(text, start, end)
 module.exports = {
 	getDate: function (text)
 	{
-		var date = new Date();
+		var date = new Date(moment().startOf('day'));
 		if (checkIfTomorrow(text))
 		{
 			date.setDate(date.getDate() + 1);

--- a/src/parse-text.js
+++ b/src/parse-text.js
@@ -1,13 +1,103 @@
+var moment = require('moment');
+
+function adjustHours (text, start, end, hours)
+{
+	var fixedHours = hours;
+	if (text.substring(start, end).includes('PM') || text.substring(start, end).includes('pm'))
+	{
+		if (hours < 12)
+		{
+			fixedHours += 12;
+		}
+	}
+	if (text.substring(start, end).includes('AM') || text.substring(start, end).includes('am'))
+	{
+		if (hours === 12)
+		{
+			fixedHours = 0;
+		}
+	}
+	return fixedHours;
+}
+
+function extractHoursMinutesFromString(text, searchStartIndex, searchEndIndex)
+{
+	var reachedStartOfTime = false;
+	var startOfTimeIndex, timeString, hours;
+	for (var i = searchStartIndex; i < searchEndIndex; i += 1)
+	{
+		if (!reachedStartOfTime && !isNaN(text.charAt(i)))
+		{
+			reachedStartOfTime = true;
+			startOfTimeIndex = i;
+		}
+		else if (reachedStartOfTime && text.charAt(i) === ':')
+		{
+			hours = adjustHours(text, searchStartIndex, searchEndIndex, parseInt(text.substring(startOfTimeIndex, i), 10));
+			timeString = `${ hours }${ text.substr(i, 3) }`
+			break;
+		}
+	}
+	if (timeString.length === 4)
+	{
+		timeString = `0${ timeString }`;
+	}
+	return timeString;
+}
+
+function checkIfTomorrow(text)
+{
+	if (text.includes('tomorrow') || text.includes('Tomorrow'))
+	{
+		return true;
+	}
+	return false;
+}
+
+
+function extractDateTime(text, start, end)
+{
+		var dateTime = new Date();
+		if (Date.parse(text.substring(start, end)))
+		{
+			dateTime = new Date(Date.parse(text.substring(start, end)));
+		}
+		else
+		{
+			if (checkIfTomorrow(text))
+			{
+				dateTime.setDate(dateTime.getDate() + 1);
+			}
+			dateTime = new Date(`${ moment(dateTime).format().substr(0, 11) }${ extractHoursMinutesFromString(text, start, end) }:00${ moment(dateTime).format().substr(19, 6) }`);
+		}
+		return dateTime;
+}
+
 module.exports = {
 	getDate: function (text)
 	{
-		if (text.includes('tomorrow'))
+		var date = new Date();
+		if (checkIfTomorrow(text))
 		{
-			var date = new Date();
 			date.setDate(date.getDate() + 1);
-			return date;
 		}
-		return new Date();
+		return date;
+	},
+	getStartDateTime: function (text)
+	{
+		return extractDateTime(text, 0, text.search(' to '))
+	},
+	getEndDateTime: function (text)
+	{
+		return extractDateTime(text, text.search(' to ') + 4, text.length);
+	},
+	checkIfDateTimeInterval: function (text)
+	{
+		if (text.includes(' to '))
+		{
+			return true;
+		}
+		return false;
 	},
 	checkIfClear: function (text)
 	{
@@ -16,5 +106,5 @@ module.exports = {
 			return true;
 		}
 		return false;
-	},
+	}
 };

--- a/src/parse-text.js
+++ b/src/parse-text.js
@@ -1,0 +1,20 @@
+module.exports = {
+	getDate: function (text)
+	{
+		if (text.includes('tomorrow'))
+		{
+			var date = new Date();
+			date.setDate(date.getDate() + 1);
+			return date;
+		}
+		return new Date();
+	},
+	checkIfClear: function (text)
+	{
+		if (text.includes('clear'))
+		{
+			return true;
+		}
+		return false;
+	},
+};

--- a/src/parse-text.js
+++ b/src/parse-text.js
@@ -57,19 +57,22 @@ function checkIfTomorrow(text)
 
 function extractDateTime(text, start, end)
 {
+		var hoursStart = start;
 		var dateTime = new Date();
-		if (Date.parse(text.substring(start, end)))
+		if (moment(text, 'MM-DD-YYYY').day())
 		{
-			dateTime = new Date(Date.parse(text.substring(start, end)));
-		}
-		else
-		{
-			if (checkIfTomorrow(text))
+			dateTime = new Date(moment(text, 'MM-DD-YYYY').format());
+			if (hoursStart === 0)
 			{
-				dateTime.setDate(dateTime.getDate() + 1);
+				hoursStart = text.search(' ');
 			}
-			dateTime = new Date(`${ moment(dateTime).format().substr(0, 11) }${ extractHoursMinutesFromString(text, start, end) }:00${ moment(dateTime).format().substr(19, 6) }`);
 		}
+		else if (checkIfTomorrow(text))
+		{
+			dateTime.setDate(dateTime.getDate() + 1);
+		}
+		dateTime = new Date(`${ moment(dateTime).format().substr(0, 11) }${ extractHoursMinutesFromString(text, hoursStart, end) }:00${ moment(dateTime).format().substr(19, 6) }`);
+
 		return dateTime;
 }
 
@@ -80,6 +83,10 @@ module.exports = {
 		if (checkIfTomorrow(text))
 		{
 			date.setDate(date.getDate() + 1);
+		}
+		else if (moment(text, 'MM-DD-YYYY').day())
+		{
+			date = new Date(moment(text, 'MM-DD-YYYY').format());
 		}
 		return date;
 	},

--- a/src/parse-text.js
+++ b/src/parse-text.js
@@ -1,4 +1,4 @@
-var moment = require('moment');
+var moment = require('moment-timezone');
 
 function getHours(text, searchStartIndex, searchEndIndex)
 {
@@ -29,12 +29,12 @@ function checkIfTomorrow(text)
 	return false;
 }
 
-function extractDateTime(text, start, end)
+function extractDateTime(timezone, text, start, end)
 {
-	var dateTime = moment().startOf('day');
+	var dateTime = moment.tz(timezone).startOf('day');
 	if (moment(text, 'MM-DD-YYYY').day())
 	{
-		dateTime = moment(text, 'MM-DD-YYYY');
+		dateTime = moment.tz(text, 'MM-DD-YYYY', timezone);
 	}
 	else if (checkIfTomorrow(text))
 	{
@@ -45,26 +45,25 @@ function extractDateTime(text, start, end)
 }
 
 module.exports = {
-	getDate: function (text)
-	{
-		var date = moment().startOf('day');
+	getDate: function (text, timezone) {
+		var date = moment.tz(timezone).startOf('Day');
 		if (checkIfTomorrow(text))
 		{
 			date.add(1, 'day');
 		}
 		else if (moment(text, 'MM-DD-YYYY').day())
 		{
-			date = moment(text, 'MM-DD-YYYY');
+			date = moment.tz(text, 'MM-DD-YYYY', timezone);
 		}
 		return date;
 	},
-	getStartDateTime: function (text)
+	getStartDateTime: function (text, timezone)
 	{
-		return extractDateTime(text, 0, text.search(' to '))
+		return extractDateTime(timezone, text, 0, text.search(' to '));
 	},
-	getEndDateTime: function (text)
+	getEndDateTime: function (text, timezone)
 	{
-		return extractDateTime(text, text.search(' to ') + 4, text.length);
+		return extractDateTime(timezone, text, text.search(' to ') + 4, text.length);
 	},
 	checkIfDateTimeInterval: function (text)
 	{

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -4,10 +4,9 @@ var queryString = require('query-string');
 module.exports = {
 	getUserInfo: function(userId) {
 		var params = queryString.stringify({
-			token: process.env.SLACK_API_TOKEN,
+			token: process.env.SLACK_API_KEY,
 			user: userId
 		});
-
 		return fetch(`https://slack.com/api/users.info?${ params }`)
 			.then(response => {
 				if (response.status === 200) {

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -18,6 +18,22 @@ module.exports = {
 			})
 			.then(slackApiResponse => slackApiResponse.user.real_name);
 	},
+	getUserTimezone: function(userId) {
+		var params = queryString.stringify({
+			token: process.env.SLACK_API_KEY,
+			user: userId
+		});
+		return fetch(`https://slack.com/api/users.info?${ params }`)
+			.then(response => {
+				if (response.status === 200) {
+					return response.json();
+				}
+				else {
+					throw new Error('Cannot connect to the Slack API.');
+				}
+			})
+			.then(slackApiResponse => slackApiResponse.user.tz);
+	},
 	sendResponse: function(url, text) {
 		return fetch(url, {
 			method: 'POST',

--- a/test/google-calendar-api.spec.js
+++ b/test/google-calendar-api.spec.js
@@ -28,7 +28,7 @@ describe('Google Calendar API', () => {
 		date = new Date(chance.date({ year: 2017 }));
 	});
 
-	describe('Checking if an existing WFH event exists', () => {
+	describe('Checking if an existing WFH event exists (not in time interval)', () => {
 		var apiResponse, employeeName, resolvedResult;
 		var act = () => resolvedResult = googleApiWrapper.checkIfWfhEventExists(employeeName, date);
 
@@ -75,7 +75,57 @@ describe('Google Calendar API', () => {
 			});
 		});
 	});
+	describe('Checking if an existing WFH event exists in time interval', () => {
+		var apiResponse, employeeName, resolvedResult, startDateTime, endDateTime;
+		var act = () => resolvedResult = googleApiWrapper.checkIfWfhEventExistsInInterval(employeeName, startDateTime, endDateTime);
 
+		beforeEach(() => {
+			apiResponse = {};
+			employeeName = chance.name();
+			fakeCalendarApi.list = sinon.stub().callsArgWith(1, null, apiResponse);
+		});
+
+		describe('And there is already an event with a summary matching the event template like "Person - WFH"', () => {
+			var eventId;
+
+			beforeEach(() => {
+				eventId = chance.string();
+				apiResponse.items = [{ id: eventId, summary: `${ employeeName } - WFH` }];
+				startDateTime = new Date(chance.date({ year: 2017 }));
+				endDateTime = new Date(chance.date({ year: 2017 }));
+				return act();
+			});
+
+			it('should pass in the GOOGLE_CLIENT_EMAIL environmental variable as the "calenderId"', () =>
+				expect(fakeCalendarApi.list.firstCall.args[0].calendarId).to.equal(clientEmail)
+			);
+
+			it('should set the "timeMin" to event date', () =>
+				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMin).format(), moment(startDateTime).format())
+			);
+
+			it('should set the "timeMax" parameter to day after event date', () =>
+				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMax).format(), moment(endDateTime).format())
+			);
+
+			it('should find that event ID', () =>
+				expect(resolvedResult).to.eventually.equal(eventId)
+			);
+		});
+
+		describe('And there is not already a WFH event', () => {
+			beforeEach(() => {
+				apiResponse.items = [{ id: chance.string(), summary: `${ chance.name({ middle: true }) } - WFH` }];
+				startDateTime = new Date(chance.date({ year: 2017 }));
+				endDateTime = new Date(chance.date({ year: 2017 }));
+				return act();
+			});
+
+			it('should not find that event', () => {
+				expect(resolvedResult).to.eventually.not.be.ok
+			});
+		});
+	});
 	describe('Deleting a WFH event', () => {
 		var error, eventId;
 		var act = () => googleApiWrapper.deleteWfhEvent(eventId);
@@ -113,56 +163,107 @@ describe('Google Calendar API', () => {
 
 	describe('Creating a WFH event', () => {
 		var employeeName, resolvedResult;
-		var act = () => resolvedResult = googleApiWrapper.createWfhEvent(employeeName, date);
+		describe('And there is not a time interval', () => {
+			var act = () => resolvedResult = googleApiWrapper.createWfhEvent(employeeName, date);
 
-		beforeEach(() => {
-			employeeName = chance.name();
-		});
-
-		describe('And the event creation succeeds', () => {
 			beforeEach(() => {
-				fakeCalendarApi.insert = sinon.stub().callsArg(1, null, {});
-				return act();
+				employeeName = chance.name();
 			});
 
-			it('should pass in "primary" as the "calendarId"', () =>
-				expect(fakeCalendarApi.insert.firstCall.args[0].calendarId).to.equal('primary')
-			);
+			describe('And the event creation succeeds', () => {
+				beforeEach(() => {
+					fakeCalendarApi.insert = sinon.stub().callsArg(1, null, {});
+					return act();
+				});
 
-			it('should add the GOOGLE_TARGET_CALENDAR environmental variable as an attendee', () => {
-				var attendees = fakeCalendarApi.insert.firstCall.args[0].resource.attendees;
-				expect(attendees).to.have.length(1);
-				expect(attendees[0]).to.have.property('email', targetCalendar);
+				it('should pass in "primary" as the "calendarId"', () =>
+					expect(fakeCalendarApi.insert.firstCall.args[0].calendarId).to.equal('primary')
+				);
+
+				it('should add the GOOGLE_TARGET_CALENDAR environmental variable as an attendee', () => {
+					var attendees = fakeCalendarApi.insert.firstCall.args[0].resource.attendees;
+					expect(attendees).to.have.length(1);
+					expect(attendees[0]).to.have.property('email', targetCalendar);
+				});
+
+				it('should resolve the returned promise', () =>
+					expect(resolvedResult).to.eventually.be.fulfilled
+				)
+
+				it('should set the start time to start of event date day', () =>
+					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).isSame(moment(date), 'day')).to.equal(true)
+				);
+
+				it('should set the end time to start of day after event date', () =>
+					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).isSame(moment(date).add(1, 'day'), 'day')).to.equal(true)
+				);
+
+				it('should set the summary to the employee\'s name plus "WFH"', () =>
+					expect(fakeCalendarApi.insert.firstCall.args[0].resource.summary).to.equal(`${ employeeName } - WFH`)
+				);
 			});
 
-			it('should resolve the returned promise', () =>
-				expect(resolvedResult).to.eventually.be.fulfilled
-			)
-
-			it('should set the start time to start of event date day', () =>
-				expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).isSame(moment(date), 'day')).to.equal(true)
-			);
-
-			it('should set the end time to start of day after event date', () =>
-				expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).isSame(moment(date).add(1, 'day'), 'day')).to.equal(true)
-			);
-
-			it('should set the summary to the employee\'s name plus "WFH"', () =>
-				expect(fakeCalendarApi.insert.firstCall.args[0].resource.summary).to.equal(`${ employeeName } - WFH`)
-			);
-		});
-
-		describe('And the event doesn\'t exist or the API errors out', () => {
+			describe('And the event doesn\'t exist or the API errors out', () => {
 			var error;
+				beforeEach(() => {
+					error = {};
+					fakeCalendarApi.insert = sinon.stub().callsArgWith(1, error);
+				});
 
-			beforeEach(() => {
-				error = {};
-				fakeCalendarApi.insert = sinon.stub().callsArgWith(1, error);
+				it('should reject the returned Promise with the error', () =>
+					expect(act()).to.be.rejectedWith(error)
+				);
+			});
+		});
+		describe('And there is a time interval ', () => {
+			var startDateTime, endDateTime;
+			var act = () => resolvedResult = googleApiWrapper.createWfhEventInInterval(employeeName, startDateTime, endDateTime);
+			describe('And the event creation succeeds', () => {
+				beforeEach(() => {
+					fakeCalendarApi.insert = sinon.stub().callsArg(1, null, {});
+					startDateTime = new Date(chance.date({ year: 2017 }));
+					endDateTime = new Date(chance.date({ year: 2017 }));
+					return act();
+				});
+
+				it('should pass in "primary" as the "calendarId"', () =>
+					expect(fakeCalendarApi.insert.firstCall.args[0].calendarId).to.equal('primary')
+				);
+
+				it('should add the GOOGLE_TARGET_CALENDAR environmental variable as an attendee', () => {
+					var attendees = fakeCalendarApi.insert.firstCall.args[0].resource.attendees;
+					expect(attendees).to.have.length(1);
+					expect(attendees[0]).to.have.property('email', targetCalendar);
+				});
+
+				it('should resolve the returned promise', () =>
+					expect(resolvedResult).to.eventually.be.fulfilled
+				)
+
+				it('should set the start time to start of event date day', () =>
+						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).format(), moment(startDateTime).format())
+				);
+
+				it('should set the end time to start of day after event date', () =>
+						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).format(), moment(endDateTime).format())
+				);
+
+				it('should set the summary to the employee\'s name plus "WFH"', () =>
+					expect(fakeCalendarApi.insert.firstCall.args[0].resource.summary).to.equal(`${ employeeName } - WFH`)
+				);
 			});
 
-			it('should reject the returned Promise with the error', () =>
-				expect(act()).to.be.rejectedWith(error)
-			);
+			describe('And the event doesn\'t exist or the API errors out', () => {
+			var error;
+				beforeEach(() => {
+					error = {};
+					fakeCalendarApi.insert = sinon.stub().callsArgWith(1, error);
+				});
+
+				it('should reject the returned Promise with the error', () =>
+					expect(act()).to.be.rejectedWith(error)
+				);
+			});
 		});
 	});
 });

--- a/test/google-calendar-api.spec.js
+++ b/test/google-calendar-api.spec.js
@@ -1,5 +1,4 @@
 var Chance = require('chance');
-var Promise = require('bluebird');
 var chai = require('chai');
 var moment = require('moment');
 var rewire = require('rewire');
@@ -13,7 +12,7 @@ var googleApiWrapper = rewire('../src/google-calendar-api');
 var fakeCalendarApi = {};
 
 googleApiWrapper.__set__({
-	credentials: sinon.stub().returns(Promise.resolve({})),
+	credentials: sinon.stub().resolves({}),
 	calendar: fakeCalendarApi
 });
 
@@ -25,7 +24,7 @@ describe('Google Calendar API', () => {
 		targetCalendar = chance.email();
 		process.env.GOOGLE_CLIENT_EMAIL = clientEmail;
 		process.env.GOOGLE_TARGET_CALENDAR = targetCalendar;
-		date = new Date(chance.date({ year: 2017 }));
+		date = moment(chance.date({ year: 2017 }));
 	});
 
 	describe('Checking if an existing WFH event exists', () => {
@@ -53,11 +52,11 @@ describe('Google Calendar API', () => {
 				);
 
 				it('should set the "timeMin" to event date', () =>
-					expect(moment(fakeCalendarApi.list.firstCall.args[0].timeMin).isSame(moment(date), 'day')).to.equal(true)
+					expect(moment(fakeCalendarApi.list.firstCall.args[0].timeMin).isSame(date, 'day')).to.equal(true)
 				);
 
 				it('should set the "timeMax" parameter to day after event date', () =>
-					expect(moment(fakeCalendarApi.list.firstCall.args[0].timeMax).isSame(moment(date).add(1, 'day'), 'day')).to.equal(true)
+					expect(moment(fakeCalendarApi.list.firstCall.args[0].timeMax).isSame(date.add(1, 'day'), 'day')).to.equal(true)
 				);
 
 				it('should find that event ID', () =>
@@ -91,8 +90,8 @@ describe('Google Calendar API', () => {
 			beforeEach(() => {
 				eventId = chance.string();
 				apiResponse.items = [{ id: eventId, summary: `${ employeeName } - WFH` }];
-				startDateTime = new Date(chance.date({ year: 2017 }));
-				endDateTime = new Date(chance.date({ year: 2017 }));
+				startDateTime = moment(chance.date({ year: 2017 }));
+				endDateTime = moment(chance.date({ year: 2017 }));
 				return act();
 			});
 
@@ -101,11 +100,11 @@ describe('Google Calendar API', () => {
 			);
 
 			it('should set the "timeMin" to the start time', () =>
-				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMin).format(), moment(startDateTime).format())
+				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMin).isSame(startDateTime, 'minute'), true)
 			);
 
 			it('should set the "timeMax" parameter to the end time', () =>
-				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMax).format(), moment(endDateTime).format())
+				sinon.assert.match(moment(fakeCalendarApi.list.firstCall.args[0].timeMax).isSame(endDateTime, 'minute'), true)
 			);
 
 			it('should find that event ID', () =>
@@ -116,8 +115,8 @@ describe('Google Calendar API', () => {
 			describe('And there is not already a WFH event', () => {
 				beforeEach(() => {
 					apiResponse.items = [{ id: chance.string(), summary: `${ chance.name({ middle: true }) } - WFH` }];
-					startDateTime = new Date(chance.date({ year: 2017 }));
-					endDateTime = new Date(chance.date({ year: 2017 }));
+					startDateTime = moment(chance.date({ year: 2017 }));
+					endDateTime = moment(chance.date({ year: 2017 }));
 					return act();
 				});
 
@@ -193,11 +192,11 @@ describe('Google Calendar API', () => {
 				)
 
 				it('should set the start time to start of event date day', () =>
-					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).isSame(moment(date), 'day')).to.equal(true)
+					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).isSame(date, 'day')).to.equal(true)
 				);
 
 				it('should set the end time to start of day after event date', () =>
-					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).isSame(moment(date).add(1, 'day'), 'day')).to.equal(true)
+					expect(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).isSame(date.add(1, 'day'), 'day')).to.equal(true)
 				);
 
 				it('should set the summary to the employee\'s name plus "WFH"', () =>
@@ -223,8 +222,8 @@ describe('Google Calendar API', () => {
 			describe('And the event creation succeeds', () => {
 				beforeEach(() => {
 					fakeCalendarApi.insert = sinon.stub().callsArg(1, null, {});
-					startDateTime = new Date(chance.date({ year: 2017 }));
-					endDateTime = new Date(chance.date({ year: 2017 }));
+					startDateTime = moment(chance.date({ year: 2017 }));
+					endDateTime = moment(chance.date({ year: 2017 }));
 					return act();
 				});
 
@@ -243,11 +242,11 @@ describe('Google Calendar API', () => {
 				)
 
 				it('should set the start time to the specified start time', () =>
-						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).format(), moment(startDateTime).format())
+						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.start.dateTime).isSame(startDateTime, 'minute'), true)
 				);
 
 				it('should set the end time to the specified end time', () =>
-						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).format(), moment(endDateTime).format())
+						sinon.assert.match(moment(fakeCalendarApi.insert.firstCall.args[0].resource.end.dateTime).isSame(endDateTime, 'minute'), true)
 				);
 
 				it('should set the summary to the employee\'s name plus "WFH"', () =>

--- a/test/handle-wfh-request.spec.js
+++ b/test/handle-wfh-request.spec.js
@@ -10,7 +10,7 @@ var chance = new Chance();
 var handleWfhRequest = rewire('../src/handle-wfh-request');
 
 describe('Handling a WFH request', () => {
-	var fakeSlackApi, fakeGoogleApi, slackResponseEndpoint, userId, date;
+	var fakeSlackApi, fakeGoogleApi, slackResponseEndpoint, userId, date, startDateTime, endDateTime;
 	var refreshMocks = () => {
 		fakeSlackApi = {
 			getUserInfo: sinon.stub(),
@@ -34,11 +34,12 @@ describe('Handling a WFH request', () => {
 		userId = chance.string();
 		slackResponseEndpoint = chance.url();
 		date = moment(chance.date());
+		startDateTime = moment(chance.date());
+		endDateTime = moment(chance.date());
 		refreshMocks();
 	});
-
-	describe('When processing a full day request', () => {
-		var act = () => handleWfhRequest.handleRequest(userId, slackResponseEndpoint, date);
+	describe('When processing a request to set a WFH event', () => {
+		var act = () => handleWfhRequest.setWfhEvent(userId, slackResponseEndpoint, startDateTime, endDateTime);
 		describe('And the Slack API returns the user\'s real name', () => {
 			var employeeName;
 
@@ -47,131 +48,20 @@ describe('Handling a WFH request', () => {
 				fakeSlackApi.getUserInfo.resolves(employeeName);
 			});
 
-			describe('And the user already submitted a /wfh request for requested date', () => {
+			describe('And the user already scheduled a wfh event for that time', () => {
 				var existingWfhEventId;
 
 				beforeEach(() => {
 					existingWfhEventId = chance.string();
 					fakeGoogleApi.checkIfWfhEventExists.resolves(existingWfhEventId);
-				});
-
-				describe('And the Google API calender deletion request is issued correctly', () => {
-					beforeEach(() => {
-						fakeGoogleApi.deleteWfhEvent.resolves();
-						return act();
-					});
-
-					it('should call the Google API to delete the existing WFH event', () =>
-						sinon.assert.calledWith(fakeGoogleApi.deleteWfhEvent, existingWfhEventId)
-					);
-
-					it('should send a response back to Slack telling the user a message about how it was deleted', () =>
-						sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-					);
-				});
-
-				describe('And there is an problem issuing the Google API request to delete the event', () => {
-					beforeEach(() => {
-						fakeGoogleApi.deleteWfhEvent.rejects();
-						return act();
-					});
-
-					it('should send a response back to Slack telling the user something went wrong', () =>
-						sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-					);
-				});
-			})
-
-			describe('And the user didn\'t already submit a /wfh request for requested date', () => {
-				beforeEach(() => {
-					fakeGoogleApi.checkIfWfhEventExists.resolves();
-					fakeGoogleApi.createWfhEvent.resolves();
 					return act();
 				});
 
-				it('should call the Google API to create the WFH event', () =>
-					sinon.assert.calledWith(fakeGoogleApi.createWfhEvent, employeeName, date)
-				);
-
-				it('should send a response back to Slack telling the user the WFH event was created', () =>
+				it('should send a response back to Slack telling the user they are already on the calendar', () =>
 					sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
 				);
 			});
-		});
-
-		describe('And there is an issue connecting with the Slack API', () => {
-			beforeEach(() => {
-				fakeSlackApi.getUserInfo.rejects();
-				return act();
-			});
-
-			it('should send a response back to Slack telling the user something went wrong', () =>
-				sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-			);
-		});
-
-		describe('And there is an issue connecting with the Google API', () => {
-			beforeEach(() => {
-				fakeSlackApi.getUserInfo.resolves(chance.name());
-				fakeGoogleApi.checkIfWfhEventExists.rejects();
-				return act();
-			});
-
-			it('should send a response back to Slack telling the user something went wrong', () =>
-				sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-			);
-		});
-	});
-	describe('When processing a time interval request', () => {
-		var startDateTime, endDateTime;
-		var act = () => handleWfhRequest.handleRequestInInterval(userId, slackResponseEndpoint, startDateTime, endDateTime);
-
-		describe('And the Slack API returns the user\'s real name', () => {
-			var employeeName;
-
-			beforeEach(() => {
-				employeeName = chance.name();
-				startDateTime = moment(chance.date());
-				endDateTime = moment(chance.date());
-				fakeSlackApi.getUserInfo.resolves(employeeName);
-			});
-
-			describe('And the user already submitted a /wfh request for requested date', () => {
-				var existingWfhEventId;
-
-				beforeEach(() => {
-					existingWfhEventId = chance.string();
-					fakeGoogleApi.checkIfWfhEventExists.resolves(existingWfhEventId);
-				});
-
-				describe('And the Google API calender deletion request is issued correctly', () => {
-					beforeEach(() => {
-						fakeGoogleApi.deleteWfhEvent.resolves();
-						return act();
-					});
-
-					it('should call the Google API to delete the existing WFH event', () =>
-						sinon.assert.calledWith(fakeGoogleApi.deleteWfhEvent, existingWfhEventId)
-					);
-
-					it('should send a response back to Slack telling the user a message about how it was deleted', () =>
-						sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-					);
-				});
-
-				describe('And there is an problem issuing the Google API request to delete the event', () => {
-					beforeEach(() => {
-						fakeGoogleApi.deleteWfhEvent.rejects();
-						return act();
-					});
-
-					it('should send a response back to Slack telling the user something went wrong', () =>
-						sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
-					);
-				});
-			})
-
-			describe('And the user didn\'t already submit a /wfh request for requested date', () => {
+			describe('And the user didn\'t already submit a /wfh request for that time', () => {
 				beforeEach(() => {
 					fakeGoogleApi.checkIfWfhEventExists.resolves();
 					fakeGoogleApi.createWfhEvent.resolves();
@@ -187,7 +77,6 @@ describe('Handling a WFH request', () => {
 				);
 			});
 		});
-
 		describe('And there is an issue connecting with the Slack API', () => {
 			beforeEach(() => {
 				fakeSlackApi.getUserInfo.rejects();

--- a/test/handle-wfh-request.spec.js
+++ b/test/handle-wfh-request.spec.js
@@ -9,13 +9,13 @@ var chance = new Chance();
 var handleWfhRequest = rewire('../src/handle-wfh-request');
 
 describe('Handling a WFH request', () => {
-	var fakeSlackApi, fakeGoogleApi, slackResponseEndpoint, userId;
-	var act = () => handleWfhRequest(userId, slackResponseEndpoint);
+	var fakeSlackApi, fakeGoogleApi, slackResponseEndpoint, userId, date;
 	var refreshMocks = () => {
 		fakeSlackApi = {
 			getUserInfo: sinon.stub(),
 			sendResponse: sinon.stub()
 		};
+
 		fakeGoogleApi = {
 			createWfhEvent: sinon.stub(),
 			checkIfWfhEventExists: sinon.stub(),
@@ -23,6 +23,7 @@ describe('Handling a WFH request', () => {
 		};
 
 		handleWfhRequest.__set__({
+			credentials: sinon.stub().returns(Promise.resolve({})),
 			slackApi: fakeSlackApi,
 			googleApi: fakeGoogleApi
 		});
@@ -31,10 +32,12 @@ describe('Handling a WFH request', () => {
 	beforeEach(() => {
 		userId = chance.string();
 		slackResponseEndpoint = chance.url();
+		date = new Date(chance.date());
 		refreshMocks();
 	});
 
 	describe('When processing a request', () => {
+		var act = () => handleWfhRequest.handleRequest(userId, slackResponseEndpoint, date);
 		describe('And the Slack API returns the user\'s real name', () => {
 			var employeeName;
 
@@ -43,7 +46,7 @@ describe('Handling a WFH request', () => {
 				fakeSlackApi.getUserInfo.resolves(employeeName);
 			});
 
-			describe('And the user already submitted a /wfh request today', () => {
+			describe('And the user already submitted a /wfh request for requested date', () => {
 				var existingWfhEventId;
 
 				beforeEach(() => {
@@ -66,7 +69,7 @@ describe('Handling a WFH request', () => {
 					);
 				});
 
-				describe('And there is an problem issuing the Google API request to delet the event', () => {
+				describe('And there is an problem issuing the Google API request to delete the event', () => {
 					beforeEach(() => {
 						fakeGoogleApi.deleteWfhEvent.rejects();
 						return act();
@@ -78,7 +81,7 @@ describe('Handling a WFH request', () => {
 				});
 			})
 
-			describe('And the user didn\'t already submit a /wfh request today', () => {
+			describe('And the user didn\'t already submit a /wfh request for requested date', () => {
 				beforeEach(() => {
 					fakeGoogleApi.checkIfWfhEventExists.resolves();
 					fakeGoogleApi.createWfhEvent.resolves();
@@ -86,7 +89,7 @@ describe('Handling a WFH request', () => {
 				});
 
 				it('should call the Google API to create the WFH event', () =>
-					sinon.assert.calledWith(fakeGoogleApi.createWfhEvent, employeeName)
+					sinon.assert.calledWith(fakeGoogleApi.createWfhEvent, employeeName, date)
 				);
 
 				it('should send a response back to Slack telling the user the WFH event was created', () =>
@@ -116,6 +119,43 @@ describe('Handling a WFH request', () => {
 			it('should send a response back to Slack telling the user something went wrong', () =>
 				sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
 			);
+		});
+	});
+	describe('When processing a request to clear,', () => {
+		var act = () => handleWfhRequest.clear(userId, slackResponseEndpoint, date);
+		describe('And the user already submitted a /wfh request for the requested date', () => {
+				var existingWfhEventId, employeeName;
+				beforeEach(() => {
+					employeeName = chance.name();
+					fakeSlackApi.getUserInfo.resolves(employeeName);
+					existingWfhEventId = chance.string();
+					fakeGoogleApi.checkIfWfhEventExists.resolves(existingWfhEventId);
+				});
+
+				describe('And the Google API calender deletion request is issued correctly', () => {
+					beforeEach(() => {
+						fakeGoogleApi.deleteWfhEvent.resolves();
+						return act();
+					});
+
+					it('should call the Google API to delete the existing WFH event', () =>
+						sinon.assert.calledWith(fakeGoogleApi.deleteWfhEvent, existingWfhEventId)
+					);
+
+					it('should send a response back to Slack telling the user a message about how it was deleted', () =>
+						sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
+					);
+				});
+		});
+		describe('And the user has not already submitted a /wfh request for the requested date', () => {
+				beforeEach(() => {
+					fakeSlackApi.getUserInfo.resolves(chance.name());
+					fakeGoogleApi.checkIfWfhEventExists.resolves();
+					return act();
+				});
+				it('should send a response back to Slack telling the user a message that they are not on the wfh calendar', () =>
+					sinon.assert.calledWith(fakeSlackApi.sendResponse, slackResponseEndpoint, sinon.match.string)
+				);
 		});
 	});
 });

--- a/test/handle-wfh-request.spec.js
+++ b/test/handle-wfh-request.spec.js
@@ -18,9 +18,7 @@ describe('Handling a WFH request', () => {
 
 		fakeGoogleApi = {
 			createWfhEvent: sinon.stub(),
-			createWfhEventInInterval: sinon.stub(),
 			checkIfWfhEventExists: sinon.stub(),
-			checkIfWfhEventExistsInInterval: sinon.stub(),
 			deleteWfhEvent: sinon.stub()
 		};
 
@@ -142,7 +140,7 @@ describe('Handling a WFH request', () => {
 
 				beforeEach(() => {
 					existingWfhEventId = chance.string();
-					fakeGoogleApi.checkIfWfhEventExistsInInterval.resolves(existingWfhEventId);
+					fakeGoogleApi.checkIfWfhEventExists.resolves(existingWfhEventId);
 				});
 
 				describe('And the Google API calender deletion request is issued correctly', () => {
@@ -174,13 +172,13 @@ describe('Handling a WFH request', () => {
 
 			describe('And the user didn\'t already submit a /wfh request for requested date', () => {
 				beforeEach(() => {
-					fakeGoogleApi.checkIfWfhEventExistsInInterval.resolves();
-					fakeGoogleApi.createWfhEventInInterval.resolves();
+					fakeGoogleApi.checkIfWfhEventExists.resolves();
+					fakeGoogleApi.createWfhEvent.resolves();
 					return act();
 				});
 
 				it('should call the Google API to create the WFH event', () =>
-					sinon.assert.calledWith(fakeGoogleApi.createWfhEventInInterval, employeeName, startDateTime, endDateTime)
+					sinon.assert.calledWith(fakeGoogleApi.createWfhEvent, employeeName, startDateTime, endDateTime)
 				);
 
 				it('should send a response back to Slack telling the user the WFH event was created', () =>
@@ -203,7 +201,7 @@ describe('Handling a WFH request', () => {
 		describe('And there is an issue connecting with the Google API', () => {
 			beforeEach(() => {
 				fakeSlackApi.getUserInfo.resolves(chance.name());
-				fakeGoogleApi.checkIfWfhEventExistsInInterval.rejects();
+				fakeGoogleApi.checkIfWfhEventExists.rejects();
 				return act();
 			});
 

--- a/test/handle-wfh-request.spec.js
+++ b/test/handle-wfh-request.spec.js
@@ -142,7 +142,7 @@ describe('Handling a WFH request', () => {
 
 				beforeEach(() => {
 					existingWfhEventId = chance.string();
-					fakeGoogleApi.checkIfWfhEventExists.resolves(existingWfhEventId);
+					fakeGoogleApi.checkIfWfhEventExistsInInterval.resolves(existingWfhEventId);
 				});
 
 				describe('And the Google API calender deletion request is issued correctly', () => {
@@ -174,8 +174,8 @@ describe('Handling a WFH request', () => {
 
 			describe('And the user didn\'t already submit a /wfh request for requested date', () => {
 				beforeEach(() => {
-					fakeGoogleApi.checkIfWfhEventExists.resolves();
-					fakeGoogleApi.createWfhEvent.resolves();
+					fakeGoogleApi.checkIfWfhEventExistsInInterval.resolves();
+					fakeGoogleApi.createWfhEventInInterval.resolves();
 					return act();
 				});
 
@@ -203,7 +203,7 @@ describe('Handling a WFH request', () => {
 		describe('And there is an issue connecting with the Google API', () => {
 			beforeEach(() => {
 				fakeSlackApi.getUserInfo.resolves(chance.name());
-				fakeGoogleApi.checkIfWfhEventExists.rejects();
+				fakeGoogleApi.checkIfWfhEventExistsInInterval.rejects();
 				return act();
 			});
 

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -2,6 +2,7 @@ var chance = require('chance')();
 var chai = require('chai');
 var rewire = require('rewire');
 var sinon = require('sinon');
+var moment = require('moment');
 
 chai.use(require('chai-as-promised'));
 
@@ -9,25 +10,85 @@ var parseText = rewire('../src/parse-text');
 describe('Parsing Text', () => {
 	var input, date;
 	describe('When processing a request to get the date', () => {
-		var act = () => parseText.getDate(input);
-		describe('And the supplied text is tomorrow', () =>	{
+		describe('And the supplied text contains a time interval', () => {
+			var startDateTime, endDateTime, startHour, endHour;
 			beforeEach(() => {
-				input = 'tomorrow';
-				date = new Date();
-				date.setDate(date.getDate() + 1);
+				startHour = chance.hour();
+				endHour = chance.hour();
+				input = `${ startHour }:00 AM to ${ endHour }:00 PM`;
 			});
-			it('should return tomorrow\'s date', () => {
-				sinon.assert.match(act().getDate(), date.getDate());
+			it('should detect the time interval', () => {
+				sinon.assert.match(parseText.checkIfDateTimeInterval(input), true);
 			});
+			describe('And the supplied text contains tomorrow', () => {
+				beforeEach(() => {
+					date = new Date();
+					date.setDate(date.getDate() + 1);
+					input = `Tomorrow ${ input }`;
+					if (startHour < 10)
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+					}
+					else
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
+					}
+					endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+				});
+				it('should return the start date time', () => {
+					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+				});
+				it('should return the end date time', () => {
+					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+				});
+			});
+			describe('And the supplied text contains only specified times and no dates (assume today)', () => {
+				beforeEach(() => {
+					date = new Date();
+					if (startHour < 10)
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+					}
+					else
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
+					}
+					endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+				});
+				it('should return the start date time', () => {
+					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+				});
+				it('should return the end date time', () => {
+					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+				});
+
+			});
+
 		});
-		describe('And the supplied text is something else', () => {
-			beforeEach(() => {
-				input = chance.sentence();
-				date = new Date();
-				return act();
+		describe('And the supplied text does not contain a time interval', () => {
+			it('should detect that there is no time interval', () => {
+				sinon.assert.match(parseText.checkIfDateTimeInterval(chance.sentence()), false);
 			});
-			it('should return today\'s date', () => {
-				sinon.assert.match(act().getDate(), date.getDate());
+			var act = () => parseText.getDate(input);
+			describe('And the supplied text contains tomorrow', () =>	{
+				beforeEach(() => {
+					input = 'tomorrow';
+					date = new Date();
+					date.setDate(date.getDate() + 1);
+				});
+				it('should return tomorrow\'s date', () => {
+					sinon.assert.match(act().getDate(), date.getDate());
+				});
+			});
+			describe('And the supplied text is something else', () => {
+				beforeEach(() => {
+					input = chance.sentence();
+					date = new Date();
+					return act();
+				});
+				it('should return today\'s date', () => {
+					sinon.assert.match(act().getDate(), date.getDate());
+				});
 			});
 		});
 	});

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -2,14 +2,17 @@ var chance = require('chance')();
 var chai = require('chai');
 var rewire = require('rewire');
 var sinon = require('sinon');
-var moment = require('moment');
+var moment = require('moment-timezone');
 
 chai.use(require('chai-as-promised'));
 
 var parseText = rewire('../src/parse-text');
 describe('Parsing Text', () => {
-	var input, date;
+	var input, date, timezone;
 	describe('When processing a request to get the date', () => {
+		beforeEach(() => {
+			timezone = moment.tz.guess();
+		});
 		describe('And the supplied text contains a time interval \'HH:MM am/pm to HH:MM am/pm\'', () => {
 			var startDateTime, endDateTime, startHour, endHour;
 			beforeEach(() => {
@@ -22,27 +25,27 @@ describe('Parsing Text', () => {
 			});
 			describe('And the supplied text contains tomorrow', () => {
 				beforeEach(() => {
-					date = moment().add(1, 'day').startOf('day');
+					date = moment.tz(timezone).add(1, 'day').startOf('day');
 					input = `Tomorrow ${ input }`;
 					if (endHour !== 12)
 					{
 						endHour += 12;
 					}
-					startDateTime = date.clone().hours(startHour);
-					endDateTime = date.clone().hours(endHour);
+					startDateTime = date.clone().tz(timezone).hours(startHour);
+					endDateTime = date.clone().tz(timezone).hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getStartDateTime(input, timezone).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getEndDateTime(input, timezone).isSame(endDateTime, 'minute'), true);
 				});
 			});
 			describe('And the user enters a date \'MM-DD-YYYY\' before the time interval', () => {
 				var dateString;
 				beforeEach(() => {
 					dateString = chance.date({ string: true });
-					date = moment(dateString, 'MM-DD-YYYY').startOf('day');
+					date = moment.tz(dateString, 'MM-DD-YYYY', timezone).startOf('day');
 					input = `${ dateString } ${ input }`;
 					if (endHour !== 12)
 					{
@@ -52,15 +55,15 @@ describe('Parsing Text', () => {
 					endDateTime = date.clone().hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getStartDateTime(input, timezone).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getEndDateTime(input, timezone).isSame(endDateTime, 'minute'), true);
 				});
 			});
 			describe('And the user does not enter a date (assume current date))', () => {
 				beforeEach(() => {
-					date = moment().startOf('day');
+					date = moment.tz(timezone).startOf('day');
 					if (endHour !== 12)
 					{
 						endHour += 12;
@@ -69,10 +72,10 @@ describe('Parsing Text', () => {
 					endDateTime = date.clone().hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getStartDateTime(input, timezone).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
+					sinon.assert.match(parseText.getEndDateTime(input, timezone).isSame(endDateTime, 'minute'), true);
 				});
 
 			});
@@ -82,11 +85,11 @@ describe('Parsing Text', () => {
 			it('should detect that there is no time interval', () => {
 				sinon.assert.match(parseText.checkIfDateTimeInterval(chance.sentence()), false);
 			});
-			var act = () => parseText.getDate(input);
+			var act = () => parseText.getDate(input, timezone);
 			describe('And the supplied text contains tomorrow', () =>	{
 				beforeEach(() => {
 					input = 'tomorrow';
-					date = moment().add(1, 'day').startOf('day');
+					date = moment.tz(timezone).startOf('day').add(1, 'day');
 				});
 				it('should return tomorrow\'s date', () => {
 					sinon.assert.match(act().isSame(date, 'minute'), true);
@@ -95,7 +98,7 @@ describe('Parsing Text', () => {
 			describe('And the supplied text contains a date', () => {
 				beforeEach(() => {
 					input = chance.date({ string: true });
-					date = moment(input, 'MM-DD-YYYY');
+					date = moment.tz(input, 'MM-DD-YYYY', timezone);
 				});
 				it('should return the entered date', () => {
 					sinon.assert.match(act().isSame(date, 'minute'), true);
@@ -104,7 +107,7 @@ describe('Parsing Text', () => {
 			describe('And the supplied text does not contain a date', () => {
 				beforeEach(() => {
 					input = chance.sentence();
-					date = moment().startOf('day');
+					date = moment.tz(timezone).startOf('day');
 				});
 				it('should return today\'s date', () => {
 					sinon.assert.match(act().isSame(date, 'minute'), true);

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -10,7 +10,7 @@ var parseText = rewire('../src/parse-text');
 describe('Parsing Text', () => {
 	var input, date;
 	describe('When processing a request to get the date', () => {
-		describe('And the supplied text contains a time interval', () => {
+		describe('And the supplied text contains a time interval \'HH:MM am/pm to HH:MM am/pm\'', () => {
 			var startDateTime, endDateTime, startHour, endHour;
 			beforeEach(() => {
 				startHour = chance.hour();
@@ -33,7 +33,14 @@ describe('Parsing Text', () => {
 					{
 						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
 					}
-					endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+					if (endHour === 12)
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
+					}
+					else
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+					}
 				});
 				it('should return the start date time', () => {
 					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
@@ -42,7 +49,37 @@ describe('Parsing Text', () => {
 					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
 				});
 			});
-			describe('And the supplied text contains only specified times and no dates (assume today)', () => {
+			describe('And the user enters a date \'MM-DD-YYYY\' before the time interval', () => {
+				var dateString;
+				beforeEach(() => {
+					dateString = chance.date({ string: true });
+					date = new Date(moment(dateString, 'MM-DD-YYYY').format());
+					input = `${ dateString } ${ input }`;
+					if (startHour < 10)
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+					}
+					else
+					{
+						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
+					}
+					if (endHour === 12)
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
+					}
+					else
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+					}
+				});
+				it('should return the start date time', () => {
+					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+				});
+				it('should return the end date time', () => {
+					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+				});
+		});
+			describe('And the user does not enter a date (assume current date))', () => {
 				beforeEach(() => {
 					date = new Date();
 					if (startHour < 10)
@@ -53,7 +90,14 @@ describe('Parsing Text', () => {
 					{
 						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
 					}
-					endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+					if (endHour === 12)
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
+					}
+					else
+					{
+						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
+					}
 				});
 				it('should return the start date time', () => {
 					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
@@ -80,7 +124,16 @@ describe('Parsing Text', () => {
 					sinon.assert.match(act().getDate(), date.getDate());
 				});
 			});
-			describe('And the supplied text is something else', () => {
+			describe('And the supplied text contains a date', () => {
+				beforeEach(() => {
+					input = chance.date({ string: true });
+					date = new Date(moment(input, 'MM-DD-YYYY').format());
+				});
+				it('should return the entered date', () => {
+					sinon.assert.match(act().getDate(), date.getDate());
+				});
+			});
+			describe('And the supplied text does not contain a date', () => {
 				beforeEach(() => {
 					input = chance.sentence();
 					date = new Date();

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -22,88 +22,57 @@ describe('Parsing Text', () => {
 			});
 			describe('And the supplied text contains tomorrow', () => {
 				beforeEach(() => {
-					date = new Date();
-					date.setDate(date.getDate() + 1);
+					date = moment().add(1, 'day').startOf('day');
 					input = `Tomorrow ${ input }`;
-					if (startHour < 10)
+					if (endHour !== 12)
 					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+						endHour += 12;
 					}
-					else
-					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
-					}
-					if (endHour === 12)
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
-					}
-					else
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
-					}
+					startDateTime = date.clone().hours(startHour);
+					endDateTime = date.clone().hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
 				});
 			});
 			describe('And the user enters a date \'MM-DD-YYYY\' before the time interval', () => {
 				var dateString;
 				beforeEach(() => {
 					dateString = chance.date({ string: true });
-					date = new Date(moment(dateString, 'MM-DD-YYYY').format());
+					date = moment(dateString, 'MM-DD-YYYY').startOf('day');
 					input = `${ dateString } ${ input }`;
-					if (startHour < 10)
+					if (endHour !== 12)
 					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+						endHour += 12;
 					}
-					else
-					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
-					}
-					if (endHour === 12)
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
-					}
-					else
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
-					}
+					startDateTime = date.clone().hours(startHour);
+					endDateTime = date.clone().hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
 				});
 			});
 			describe('And the user does not enter a date (assume current date))', () => {
 				beforeEach(() => {
-					date = new Date();
-					if (startHour < 10)
+					date = moment().startOf('day');
+					if (endHour !== 12)
 					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } 0${ startHour }:00:00`);
+						endHour += 12;
 					}
-					else
-					{
-						startDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ startHour }:00:00`);
-					}
-					if (endHour === 12)
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour }:00:00`);
-					}
-					else
-					{
-						endDateTime = new Date(`${ moment(date).format('MMMM') } ${ moment(date).format('D') }, ${ moment(date).format('YYYY') } ${ endHour + 12 }:00:00`);
-					}
+					startDateTime = date.clone().hours(startHour);
+					endDateTime = date.clone().hours(endHour);
 				});
 				it('should return the start date time', () => {
-					sinon.assert.match(parseText.getStartDateTime(input), startDateTime);
+					sinon.assert.match(parseText.getStartDateTime(input).isSame(startDateTime, 'minute'), true);
 				});
 				it('should return the end date time', () => {
-					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
+					sinon.assert.match(parseText.getEndDateTime(input).isSame(endDateTime, 'minute'), true);
 				});
 
 			});
@@ -117,30 +86,28 @@ describe('Parsing Text', () => {
 			describe('And the supplied text contains tomorrow', () =>	{
 				beforeEach(() => {
 					input = 'tomorrow';
-					date = new Date();
-					date.setDate(date.getDate() + 1);
+					date = moment().add(1, 'day').startOf('day');
 				});
 				it('should return tomorrow\'s date', () => {
-					sinon.assert.match(act().getDate(), date.getDate());
+					sinon.assert.match(act().isSame(date, 'minute'), true);
 				});
 			});
 			describe('And the supplied text contains a date', () => {
 				beforeEach(() => {
 					input = chance.date({ string: true });
-					date = new Date(moment(input, 'MM-DD-YYYY').format());
+					date = moment(input, 'MM-DD-YYYY');
 				});
 				it('should return the entered date', () => {
-					sinon.assert.match(act().getDate(), date.getDate());
+					sinon.assert.match(act().isSame(date, 'minute'), true);
 				});
 			});
 			describe('And the supplied text does not contain a date', () => {
 				beforeEach(() => {
 					input = chance.sentence();
-					date = new Date();
-					return act();
+					date = moment().startOf('day');
 				});
 				it('should return today\'s date', () => {
-					sinon.assert.match(act().getDate(), date.getDate());
+					sinon.assert.match(act().isSame(date, 'minute'), true);
 				});
 			});
 		});

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -1,0 +1,53 @@
+var chance = require('chance')();
+var chai = require('chai');
+var rewire = require('rewire');
+var sinon = require('sinon');
+
+chai.use(require('chai-as-promised'));
+
+var parseText = rewire('../src/parse-text');
+describe('Parsing Text', () => {
+	var input, date;
+	describe('When processing a request to get the date', () => {
+		var act = () => parseText.getDate(input);
+		describe('And the supplied text is tomorrow', () =>	{
+			beforeEach(() => {
+				input = 'tomorrow';
+				date = new Date();
+				date.setDate(date.getDate() + 1);
+			});
+			it('should return tomorrow\'s date', () => {
+				sinon.assert.match(act().getDate(), date.getDate());
+			});
+		});
+		describe('And the supplied text is something else', () => {
+			beforeEach(() => {
+				input = chance.sentence();
+				date = new Date();
+				return act();
+			});
+			it('should return today\'s date', () => {
+				sinon.assert.match(act().getDate(), date.getDate());
+			});
+		});
+	});
+	describe('When processing a request to checkIfClear', () => {
+		var act = () => parseText.checkIfClear(input);
+		describe('And the text is \'clear\'', () => {
+			beforeEach(() => {
+				input = 'clear';
+			});
+			it('should return true', () => {
+				sinon.assert.match(act(), true);
+			});
+		});
+		describe('And the text is some random other text', () => {
+			beforeEach(() => {
+				input = chance.sentence();
+			});
+			it('should return false', () => {
+				sinon.assert.match(act(), false);
+			});
+		});
+	});
+});

--- a/test/parse-text.spec.js
+++ b/test/parse-text.spec.js
@@ -78,7 +78,7 @@ describe('Parsing Text', () => {
 				it('should return the end date time', () => {
 					sinon.assert.match(parseText.getEndDateTime(input), endDateTime);
 				});
-		});
+			});
 			describe('And the user does not enter a date (assume current date))', () => {
 				beforeEach(() => {
 					date = new Date();


### PR DESCRIPTION
Added functionality to allow users to schedule future WFH events and changed the` /wfh` command to use explicit destructive actions with the word `clear`. Examples of use:
`/wfh` sets a full day WFH event on current date if one does not exist
`/wfh clear` deletes WFH event from current date if one exists
`/wfh tomorrow 10:00am to 6:00pm` sets a WFH event on tomorrow's date in time range if one does not exist
`/wfh 6-9-2017 10:00am to 6:00pm` schedules a WFH event on date in time range if one does not exist
`/wfh 6-9-2017 9:00am to 6:00pm clear` deletes WFH event on date in time range if one exists